### PR TITLE
perf: reuse HTTP session to avoid repeated TLS handshakes

### DIFF
--- a/core/accountDataFetcher.py
+++ b/core/accountDataFetcher.py
@@ -7,6 +7,8 @@ from curl_cffi import requests
 from utils.colorPrinter import *
 from datetime import datetime
 
+_session = requests.Session()
+
 
 def get_time():
     return datetime.now().strftime("%H:%M:%S")
@@ -23,7 +25,7 @@ def fetch_data(username, debug=False):
         headers = {
             "X-IG-App-ID": "936619743392459",
         }
-        response = requests.get(url, headers=headers)
+        response = _session.get(url, headers=headers)
 
         if response.status_code != 200:
             error_handler(response, debug)

--- a/core/mediaDownloader.py
+++ b/core/mediaDownloader.py
@@ -8,6 +8,8 @@ from utils.colorPrinter import *
 from datetime import datetime
 import os
 
+_session = requests.Session()
+
 is_video = None
 media_url = None
 file_name = None
@@ -46,7 +48,7 @@ def fetch_media(url, debug=False):
         LIGHT_YELLOW_EX, "Fetching..."
     )
     
-    r = requests.get(
+    r = _session.get(
         f"https://www.instagram.com/api/v1/users/web_profile_info/?username={user_name}",
         headers={
             "X-IG-App-ID": "936619743392459",
@@ -105,7 +107,7 @@ def download_media(post_url, debug=False):
         LIGHT_YELLOW_EX, "Downloading..."
     )
 
-    r = requests.get(
+    r = _session.get(
         media_url, 
         headers={
             "X-IG-App-ID": "936619743392459"


### PR DESCRIPTION
## Summary

Replace bare \equests.get()\ calls with a module-level \curl_cffi.requests.Session()\ in both core modules.

## Problem

Every call to \equests.get()\ opens a brand-new TCP connection and performs a full TLS 1.3 handshake with \www.instagram.com\. A typical TLS handshake costs **100–300 ms** of latency. The download flow makes **two** sequential requests to the same host (profile-info fetch, then media download), paying this overhead twice.

## Fix

A \Session\ object maintains a connection pool and reuses the underlying socket for subsequent requests to the same host, so the second request skips the handshake entirely.

\\\diff
+_session = requests.Session()
 ...
-response = requests.get(url, headers=headers)
+response = _session.get(url, headers=headers)
\\\

## Impact

| Scenario | Before | After |
|---|---|---|
| \--name\ (1 request) | 1 handshake | 1 handshake |
| \--dload\ (2 requests, same host) | 2 handshakes | 1 handshake |

Saves ~100–300 ms on every \--dload\ invocation with no behaviour change.

## Changes

- \core/accountDataFetcher.py\ — module-level \_session\ used for the profile-info request  
- \core/mediaDownloader.py\ — shared \_session\ reused across the profile-info fetch and the subsequent media download